### PR TITLE
perf: 优化limit

### DIFF
--- a/sms-core/src/main/java/com/github/jackieonway/sms/core/utls/SmsCacheUtils.java
+++ b/sms-core/src/main/java/com/github/jackieonway/sms/core/utls/SmsCacheUtils.java
@@ -33,7 +33,7 @@ public class SmsCacheUtils {
      * @since 0.0.3
      */
     public static int getTimeout(Limit limit) {
-        return limit.getLimitTime();
+        return null == limit ? 60000 : limit.getLimitTime();
     }
 
     /**
@@ -46,7 +46,7 @@ public class SmsCacheUtils {
      * @since 0.0.3
      */
     public static boolean enableCache(Limit limit) {
-        return limit.isEnable();
+        return null != limit && limit.isEnable();
     }
 
     /**


### PR DESCRIPTION
在创建各Request可能会忘记Limit,导致异常